### PR TITLE
Fix MDX syntax, linting, and ignore contentlayer cache

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .vercel
 .DS_Store
 contentlayer/generated
+.contentlayer

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -64,7 +64,7 @@ export default function Page() {
         <h2 className="text-2xl font-heading font-semibold text-navy dark:text-white mb-4">Get in Touch</h2>
         <p className="text-charcoal/70 dark:text-warm/70 mb-4">
           Interested in RFID systems, factory automation, or building connected products? 
-          Let's discuss how we can work together.
+            Let&apos;s discuss how we can work together.
         </p>
         <a 
           href="/contact" 

--- a/content/work/ktl.mdx
+++ b/content/work/ktl.mdx
@@ -25,7 +25,7 @@ Built a Next.js site with:
 
 ## Outcome
 - **SEO**: 95+ Lighthouse SEO score
-- **Performance**: <2s LCP, <0.1 CLS
+- **Performance**: &lt;2s LCP, &lt;0.1 CLS
 - **Conversion**: Streamlined RFQ process
 - **Mobile**: Fully responsive across all devices
 


### PR DESCRIPTION
## Summary
- escape angle brackets in KTL case study metrics to avoid MDX parsing issues
- add minimal Next.js ESLint config and tidy About page text
- ignore `.contentlayer` output to keep working tree clean

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6c40b797483298961b1595e900ae5